### PR TITLE
Improve bounding box selection and add user agent

### DIFF
--- a/gbif_webservices.py
+++ b/gbif_webservices.py
@@ -42,8 +42,12 @@ def show_warning():
 def count_occurrences(filters):
     p = _finalize_filters(filters)
     p["offset"] = 0
+    headers = {
+        'User-Agent': 'QGIS Plugin GBIF Occurrences',
+        'From': 'https://github.com/BelgianBiodiversityPlatform/qgis-gbif-api'
+    }
     try:
-        req = requests.get(OCCURRENCES_SEARCH_URL, params=p)
+        req = requests.get(OCCURRENCES_SEARCH_URL, params=p, headers=headers)
     except requests.exceptions.ConnectionError:
         raise ConnectionIssue
     else:
@@ -79,8 +83,12 @@ def get_occurrences_in_batches(filters):
 
     while not finished:
         p["offset"] = offset
+        headers = {
+            'User-Agent': 'QGIS Plugin GBIF Occurrences',
+            'From': 'https://github.com/BelgianBiodiversityPlatform/qgis-gbif-api'
+        }
 
-        req = requests.get(OCCURRENCES_SEARCH_URL, params=p)
+        req = requests.get(OCCURRENCES_SEARCH_URL, params=p, headers=headers)
 
         resp = req.json()
 

--- a/qgis_occurrences_dialog.py
+++ b/qgis_occurrences_dialog.py
@@ -17,7 +17,7 @@ from builtins import str
 import os
 import sys
 
-from qgis.core import QgsPointXY
+from qgis.core import QgsGeometry, QgsCoordinateReferenceSystem
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QApplication, QMessageBox, QDialog
 from qgis.PyQt.QtCore import QDate, Qt
@@ -91,7 +91,6 @@ class GBIFOccurrencesDialog(QDialog, FORM_CLASS):
         self.project = project
         self.iface = iface
         self.canvas = self.iface.mapCanvas()
-        self.rectangle = None
 
         self.setupUi(self)
         self.setFixedSize(self.size())
@@ -122,14 +121,13 @@ class GBIFOccurrencesDialog(QDialog, FORM_CLASS):
         self.stop = False
         self.stopButton.clicked.connect(self.clicked_stop_button)
 
+    def showEvent(self, event):
+        self.recreate_rubber_band()
+
     def closeEvent(self, event):
         # Remove rectangle from map
         self.erase_rubber_band()
-        self.rectangle = None
-
-        # TODO change to make, for now every time the window is closed
-        self.boundariesCheckBox.setChecked(True)
-        self.localisation_selection_ui()
+        self.canvas.unsetMapTool(self.rectangle_tool)
 
     def clicked_stop_button(self):
         self.stop = True
@@ -188,7 +186,7 @@ supported.""".format(
         QMessageBox.critical(self, "Error", msg)
 
     def _ui_to_filters(self):
-        if not self.rectangle:
+        if not self.bboxCheckBox.isChecked():
             return {
                 "scientificName": self.scientificNameField.text(),
                 "basisOfRecord": self.basisComboBox.checkedItemsData(),
@@ -206,25 +204,29 @@ supported.""".format(
                 "datasetKey": self.datasetKeyField.text(),
                 "recordedBy": self.recordedByField.text(),
                 "gadm_gid": self.gadmGidField.text(),
-            }  # Hinzugefügt
+            }
         else:
-            return {
-                "scientificName": self.scientificNameField.text(),
-                "basisOfRecord": self.basisComboBox.checkedItemsData(),
-                "catalogNumber": self.catalogNumberField.text(),
-                "publishingCountry": _get_selected_country_code(
-                    self.publishingCountryComboBox
-                ),
-                "institutionCode": self.institutionCodeField.text(),
-                "collectionCode": self.collectionCodeField.text(),
-                "eventDate": _get_val_or_range(
-                    self.minDateEdit, self.maxDateEdit, self.error_message
-                ),
-                "taxonKey": str(self.taxonKeyField.value()) if self.taxonKeyField.value() != 0 else '',
-                "datasetKey": self.datasetKeyField.text(),
-                "recordedBy": self.recordedByField.text(),
-                "geometry": self.rectangle,
-            }  # Hinzugefügt
+            try:
+                self.rectangle_tool.new_extent.asWktPolygon()
+                return {
+                    "scientificName": self.scientificNameField.text(),
+                    "basisOfRecord": self.basisComboBox.checkedItemsData(),
+                    "catalogNumber": self.catalogNumberField.text(),
+                    "publishingCountry": _get_selected_country_code(
+                        self.publishingCountryComboBox
+                    ),
+                    "institutionCode": self.institutionCodeField.text(),
+                    "collectionCode": self.collectionCodeField.text(),
+                    "eventDate": _get_val_or_range(
+                        self.minDateEdit, self.maxDateEdit, self.error_message
+                    ),
+                    "taxonKey": str(self.taxonKeyField.value()) if self.taxonKeyField.value() != 0 else '',
+                    "datasetKey": self.datasetKeyField.text(),
+                    "recordedBy": self.recordedByField.text(),
+                    "geometry": self.rectangle_tool.new_extent.asWktPolygon(),
+                }
+            except AttributeError:
+                self.error_message("GBIF Error: No bounding box drawned on map canvas, press the dedicated button.")
 
     def localisation_selection_ui(self):
         if self.boundariesCheckBox.isChecked():
@@ -233,7 +235,6 @@ supported.""".format(
             self.bboxButton.setDisabled(True)
             # Remove rectangle from map
             self.erase_rubber_band()
-            self.rectangle = None
             # Remove the map tool to draw the rectangle
             self.canvas.unsetMapTool(self.rectangle_tool)
         else:
@@ -242,11 +243,28 @@ supported.""".format(
             self.gadmGidField.setDisabled(True)
             self.gadmGidField.clear()
             self.bboxButton.setDisabled(False)
+            self.recreate_rubber_band()
 
     def erase_rubber_band(self):
         # Erase the drawn rectangle
         if self.rectangle_tool.rubber_band:
             self.rectangle_tool.rubber_band.reset()
+        else:
+            pass
+
+    def recreate_rubber_band(self):
+        if self.rectangle_tool.new_extent and self.rectangle_tool.rubber_band.numberOfVertices() == 0:
+            extent4326 = self.rectangle_tool.new_extent
+            if str(self.project.instance().crs().postgisSrid()) != str(4326):
+                geom = self.rectangle_tool.transform_geom(
+                    QgsGeometry().fromRect(extent4326),
+                    QgsCoordinateReferenceSystem("EPSG:" + str(4326)),
+                    self.project.instance().crs(),
+                )
+            else:
+                geom = QgsGeometry().fromRect(extent4326)
+            self.rectangle_tool.rubber_band.setToGeometry(geom)
+            self.rectangle_tool.rubber_band.show()
         else:
             pass
 
@@ -262,13 +280,13 @@ supported.""".format(
 
     def rectangle_drawned(self):
         # Launched every time a new extent is drawned.
-        self.rectangle = self.rectangle_tool.new_extent.asWktPolygon()
         self.activate_window()
 
     def activate_window(self):
         # Put the dialog on top once the rectangle is drawn
         self.showNormal()
         self.activateWindow()
+        self.canvas.unsetMapTool(self.rectangle_tool)
 
     def load_occurrences(self):
         # Remove the map tool to draw the rectangle
@@ -281,6 +299,8 @@ supported.""".format(
             self.connection_error_message()
         except GBIFApiError as e:
             self.error_message("GBIF Error: " + str(e))
+        except AttributeError:
+            pass
         else:
             if count > MAX_TOTAL_RECORDS_GBIF:
                 self.dialog_too_many_results()

--- a/qgis_occurrences_dialog.py
+++ b/qgis_occurrences_dialog.py
@@ -127,6 +127,10 @@ class GBIFOccurrencesDialog(QDialog, FORM_CLASS):
         self.erase_rubber_band()
         self.rectangle = None
 
+        # TODO change to make, for now every time the window is closed
+        self.boundariesCheckBox.setChecked(True)
+        self.localisation_selection_ui()
+
     def clicked_stop_button(self):
         self.stop = True
 
@@ -255,7 +259,6 @@ supported.""".format(
     def set_rectangle_tool(self):
         self.rectangle_tool = RectangleDrawTool(self.project, self.canvas)
         self.rectangle_tool.signal.connect(self.rectangle_drawned)
-        self.bboxButton.setEnabled(True)
 
     def rectangle_drawned(self):
         # Launched every time a new extent is drawned.

--- a/qgis_occurrences_dialog.py
+++ b/qgis_occurrences_dialog.py
@@ -17,7 +17,7 @@ from builtins import str
 import os
 import sys
 
-
+from qgis.core import QgsPointXY
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QApplication, QMessageBox, QDialog
 from qgis.PyQt.QtCore import QDate, Qt
@@ -59,8 +59,12 @@ def _get_selected_country_code(combobox):
     return None
 
 
-def _get_val_or_range(min_field, max_field):
-    return "{min},{max}".format(min=str(min_field.date().year()), max=str(max_field.date().year()))
+def _get_val_or_range(min_field, max_field, error_message):
+    try:
+        max_field.date() >= min_field.date()
+        return "{min},{max}".format(min=str(min_field.date().toString('yyyy-MM-dd')), max=str(max_field.date().toString('yyyy-MM-dd')))
+    except GBIFApiError as e:
+        error_message("GBIF Error: " + str(e))
 
 
 class GBIFOccurrencesDialog(QDialog, FORM_CLASS):
@@ -117,6 +121,11 @@ class GBIFOccurrencesDialog(QDialog, FORM_CLASS):
 
         self.stop = False
         self.stopButton.clicked.connect(self.clicked_stop_button)
+
+    def closeEvent(self, event):
+        # Remove rectangle from map
+        self.erase_rubber_band()
+        self.rectangle = None
 
     def clicked_stop_button(self):
         self.stop = True
@@ -186,8 +195,8 @@ supported.""".format(
                 ),
                 "institutionCode": self.institutionCodeField.text(),
                 "collectionCode": self.collectionCodeField.text(),
-                "year": _get_val_or_range(
-                    self.minDateEdit, self.maxDateEdit
+                "eventDate": _get_val_or_range(
+                    self.minDateEdit, self.maxDateEdit, self.error_message
                 ),
                 "taxonKey": str(self.taxonKeyField.value()) if self.taxonKeyField.value() != 0 else '',
                 "datasetKey": self.datasetKeyField.text(),
@@ -204,13 +213,13 @@ supported.""".format(
                 ),
                 "institutionCode": self.institutionCodeField.text(),
                 "collectionCode": self.collectionCodeField.text(),
-                "year": _get_val_or_range(
-                    self.minDateEdit, self.maxDateEdit
+                "eventDate": _get_val_or_range(
+                    self.minDateEdit, self.maxDateEdit, self.error_message
                 ),
                 "taxonKey": str(self.taxonKeyField.value()) if self.taxonKeyField.value() != 0 else '',
                 "datasetKey": self.datasetKeyField.text(),
                 "recordedBy": self.recordedByField.text(),
-                "geometry": self.rectangle_tool.new_extent.asWktPolygon(),
+                "geometry": self.rectangle,
             }  # Hinzugefügt
 
     def localisation_selection_ui(self):
@@ -220,6 +229,7 @@ supported.""".format(
             self.bboxButton.setDisabled(True)
             # Remove rectangle from map
             self.erase_rubber_band()
+            self.rectangle = None
             # Remove the map tool to draw the rectangle
             self.canvas.unsetMapTool(self.rectangle_tool)
         else:
@@ -249,7 +259,7 @@ supported.""".format(
 
     def rectangle_drawned(self):
         # Launched every time a new extent is drawned.
-        self.rectangle = True
+        self.rectangle = self.rectangle_tool.new_extent.asWktPolygon()
         self.activate_window()
 
     def activate_window(self):
@@ -258,8 +268,6 @@ supported.""".format(
         self.activateWindow()
 
     def load_occurrences(self):
-        # Remove rectangle from map
-        self.erase_rubber_band()
         # Remove the map tool to draw the rectangle
         self.canvas.unsetMapTool(self.rectangle_tool)
         filters = self._ui_to_filters()

--- a/qgis_occurrences_dialog_base.ui
+++ b/qgis_occurrences_dialog_base.ui
@@ -327,7 +327,7 @@
       <item row="3" column="1">
        <widget class="QComboBox" name="countryComboBox">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -340,6 +340,9 @@
          <string>Use admin boundaries</string>
         </property>
         <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
          <bool>true</bool>
         </property>
         <attribute name="buttonGroup">
@@ -357,12 +360,15 @@
       <item row="4" column="1">
        <widget class="QLineEdit" name="gadmGidField">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QPushButton" name="bboxButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Draw a bounding box</string>
         </property>
@@ -374,7 +380,7 @@
          <string>Use a bounding box</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">localisationButtonGroup</string>

--- a/rectangle_tool.py
+++ b/rectangle_tool.py
@@ -72,18 +72,18 @@ class RectangleDrawTool(QgsMapTool):
         # Only a rectangle can be used
         if startPoint.x() == endPoint.x() or startPoint.y() == endPoint.y():
             return
+        else:
+            point1 = QgsPointXY(startPoint.x(), startPoint.y())
+            point2 = QgsPointXY(startPoint.x(), endPoint.y())
+            point3 = QgsPointXY(endPoint.x(), endPoint.y())
+            point4 = QgsPointXY(endPoint.x(), startPoint.y())
 
-        point1 = QgsPointXY(startPoint.x(), startPoint.y())
-        point2 = QgsPointXY(startPoint.x(), endPoint.y())
-        point3 = QgsPointXY(endPoint.x(), endPoint.y())
-        point4 = QgsPointXY(endPoint.x(), startPoint.y())
-
-        # Create the rectangle
-        self.rubber_band.addPoint(point1, False)
-        self.rubber_band.addPoint(point2, False)
-        self.rubber_band.addPoint(point3, False)
-        self.rubber_band.addPoint(point4, True)  # true to update canvas
-        self.rubber_band.show()
+            # Create the rectangle
+            self.rubber_band.addPoint(point1, False)
+            self.rubber_band.addPoint(point2, False)
+            self.rubber_band.addPoint(point3, False)
+            self.rubber_band.addPoint(point4, True)  # true to update canvas
+            self.rubber_band.show()
 
     def rectangle(self):
         # Only a rectangle is accepted

--- a/test/test_qgis_occurrences_dialog.py
+++ b/test/test_qgis_occurrences_dialog.py
@@ -26,9 +26,9 @@ QGIS_APP = get_qgis_app()
 
 
 def close_all_messagebox():
-        for widget in QtGui.qApp.topLevelWidgets():
-            if isinstance(widget, QtGui.QMessageBox):
-                QtTest.QTest.keyClick(widget, QtCore.Qt.Key_Enter)
+    for widget in QtGui.qApp.topLevelWidgets():
+        if isinstance(widget, QtGui.QMessageBox):
+            QtTest.QTest.keyClick(widget, QtCore.Qt.Key_Enter)
 
 
 class GBIFOccurrencesDialogTest(unittest.TestCase):


### PR DESCRIPTION
Bounding box is now removed if : 

- checkbox for location selection is changed to admin boundaries
- dialog is closed
- a new bounding box is drawn

Bounding box is recreated if : 
- checkbox for location selection is switched from admin boundaries to bounding box
- plugin dialog is reopen

The last bounding box is always kept in history so it can be used for multiple search

MapTool object is more coherent, and do not stay active once the plugin is closed

Added a simple user agent : 
`headers = {
        'User-Agent': 'QGIS Plugin GBIF Occurrences',
        'From': 'https://github.com/BelgianBiodiversityPlatform/qgis-gbif-api'
    }`

#47 